### PR TITLE
Extend rules for determine VR applications

### DIFF
--- a/Launcher/App/src/main/java/com/threethan/launcher/platforms/AbstractPlatform.java
+++ b/Launcher/App/src/main/java/com/threethan/launcher/platforms/AbstractPlatform.java
@@ -149,7 +149,17 @@ public abstract class AbstractPlatform {
 
     public static boolean isVirtualRealityApp(ApplicationInfo applicationInfo) {
         if (applicationInfo.metaData != null) {
-            return applicationInfo.metaData.keySet().contains("com.oculus.supportedDevices");
+            for (String key : applicationInfo.metaData.keySet()) {
+                if (key.contains("com.oculus.supportedDevices")) {
+                    return true;
+                }
+                if (key.contains("vr.application.mode")) {
+                    return true;
+                }
+                if (key.startsWith("notch.config")) {
+                    return true;
+                }
+            }
         }
         return false;
     }


### PR DESCRIPTION
@threethan I've just found that not all installed applications determine as VR as result it tied to run in the same window, so this changes might be useful (note: I'm not an android/java developer). 

<details>
  <summary>I've found issues with this applications</summary>
  

Don’t Touch Anything
---
_Package Name_: `com.ForwardXP.nuke`
_metaData_: `Bundle{unity.splash-enable: false, unity.launch-fullscreen: true, com.google.android.play.billingclient.version: 3.0.3, unity.allow-resizable-window: false, unity.build-id: 44bb88a5-fe3f-47bc-aab8-59530c09a7a7, unity.splash-mode: 0, notch.config: portrait|landscape}`

Star Wars: Tales from the Galaxy's Edge
---
_Package Name_: `com.ilmxlab.tales`
_metaData_:  `Bundle{com.epicgames.ue4.GameActivity.bVerifyOBBOnStartUp: false, com.epicgames.ue4.GameActivity.bPublicLogFiles: false, com.epicgames.ue4.GameActivity.EngineVersion: 4.24.3, com.epicgames.ue4.GameActivity.bUseDisplayCutout: false, com.epicgames.ue4.GameActivity.bAllowIMU: true, com.epicgames.ue4.GameActivity.bShouldHideUI: false, com.epicgames.ue4.GameActivity.StartupPermissions: , com.epicgames.ue4.GameActivity.ProjectName: Taco, com.epicgames.ue4.GameActivity.bUseExternalFilesDir: false, com.epicgames.ue4.GameActivity.DepthBufferPreference: 0, com.epicgames.ue4.GameActivity.bPackageDataInsideApk: false, com.epicgames.ue4.GameActivity.ProjectVersion: 1.1.9+734762.cl.439699, android.max_aspect: 2.1, com.google.android.gms.games.APP_ID: , com.epicgames.ue4.GameActivity.EngineBranch: ++taco+main, com.epicgames.ue4.GameActivity.AppType: , com.epicgames.ue4.GameActivity.bHasOBBFiles: true, com.samsung.android.vr.application.mode: vr_only, com.oculus.ossplash: true, com.epicgames.ue4.GameActivity.bSupportsVulkan: false, com.google.android.gms.version: 11910000, com.epicgames.ue4.GameActivity.CookedFlavors: ASTC, com.epicgames.ue4.GameActivity.BuildConfiguration: Shipping, com.epicgames.ue4.GameActivity.bValidateTextureFormats: true}`

First Steps
---
_Package Name_: `com.oculus.MiramarSetupRetail`
_metaData_: `Bundle{com.epicgames.ue4.GameActivity.bVerifyOBBOnStartUp: false, com.epicgames.ue4.GameActivity.EngineVersion: 4.18.1, com.epicgames.ue4.GameActivity.bShouldHideUI: false, com.epicgames.ue4.GameActivity.ProjectName: MontereySetup, com.epicgames.ue4.GameActivity.bUseExternalFilesDir: false, com.epicgames.ue4.GameActivity.DepthBufferPreference: 0, com.epicgames.ue4.GameActivity.bPackageDataInsideApk: true, com.oculus.release_ready: true, android.max_aspect: 2.1, com.google.android.gms.games.APP_ID: , com.epicgames.ue4.GameActivity.bHasOBBFiles: true, com.samsung.android.vr.application.mode: vr_only, com.google.android.gms.version: 11020000, com.epicgames.ue4.GameActivity.BuildConfiguration: Shipping}`

First FirstContact
---
_Package Name_: `com.Oculus.FirstContact`
_metaData_: `Bundle{com.epicgames.ue4.GameActivity.bVerifyOBBOnStartUp: false, com.epicgames.ue4.GameActivity.EngineVersion: 4.21.2, com.epicgames.ue4.GameActivity.bAllowIMU: true, com.epicgames.ue4.GameActivity.bShouldHideUI: false, com.epicgames.ue4.GameActivity.ProjectName: TouchNUX, com.epicgames.ue4.GameActivity.bUseExternalFilesDir: false, com.epicgames.ue4.GameActivity.DepthBufferPreference: 0, com.epicgames.ue4.GameActivity.bPackageDataInsideApk: false, com.epicgames.ue4.GameActivity.ProjectVersion: 1.0.0.0, android.max_aspect: 2.1, com.google.android.gms.games.APP_ID: , com.epicgames.ue4.GameActivity.EngineBranch: ++UE4+Partner-Oculus-4.21, com.epicgames.ue4.GameActivity.AppType: , com.epicgames.ue4.GameActivity.bHasOBBFiles: true, com.samsung.android.vr.application.mode: vr_only, com.epicgames.ue4.GameActivity.bSupportsVulkan: false, com.google.android.gms.version: 11910000, com.epicgames.ue4.GameActivity.CookedFlavors: ASTC, com.epicgames.ue4.GameActivity.BuildConfiguration: Shipping, com.epicgames.ue4.GameActivity.bValidateTextureFormats: true}`
  
</details>
