### PR TITLE
Fix shortcut service for non en locales

### DIFF
--- a/Launcher/App/src/main/res/values-cs/strings.xml
+++ b/Launcher/App/src/main/res/values-cs/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[Knihovna aplikací]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-da/strings.xml
+++ b/Launcher/App/src/main/res/values-da/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[Appbibliotek]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-de/strings.xml
+++ b/Launcher/App/src/main/res/values-de/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Deutch locale use No-Break Space (NBSP) Unicode Character U+00A0 instead of space -->
+    <string name="accessibility_event_name">[App Library]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-el/strings.xml
+++ b/Launcher/App/src/main/res/values-el/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[Βιβλιοθήκη εφαρμογών]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-es-rES/strings.xml
+++ b/Launcher/App/src/main/res/values-es-rES/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[Biblioteca de aplicaciones]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-es/strings.xml
+++ b/Launcher/App/src/main/res/values-es/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[Biblioteca de apps]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-fi/strings.xml
+++ b/Launcher/App/src/main/res/values-fi/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[Sovelluskirjasto]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-ja/strings.xml
+++ b/Launcher/App/src/main/res/values-ja/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[アプリライブラリ]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-ko/strings.xml
+++ b/Launcher/App/src/main/res/values-ko/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[앱 라이브러리]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-nb/strings.xml
+++ b/Launcher/App/src/main/res/values-nb/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[Appbibliotek]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-nl/strings.xml
+++ b/Launcher/App/src/main/res/values-nl/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[Appbibliotheek]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-pl/strings.xml
+++ b/Launcher/App/src/main/res/values-pl/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[Biblioteka aplikacji]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-pt-rPT/strings.xml
+++ b/Launcher/App/src/main/res/values-pt-rPT/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[Biblioteca de Apps]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-ro/strings.xml
+++ b/Launcher/App/src/main/res/values-ro/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[Biblioteca de aplicaţii]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-ru/strings.xml
+++ b/Launcher/App/src/main/res/values-ru/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[Библиотека приложений]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-ru/strings.xml
+++ b/Launcher/App/src/main/res/values-ru/strings.xml
@@ -1,4 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="default_apps_group">Игры</string>
+    <string name="android_apps_group">Инструменты</string>
+    <string name="add_group">Добавить группу</string>
+    <string name="delete_group">Удалить группу</string>
+    <string name="edit_group">Изменить группу</string>
+    <string name="app_details">О приложении</string>
+
+    <string name="background_opacity">Прозрачность фона</string>
+    <string name="icons_size">Размер иконок</string>
+    <string name="show_app_names">Показывать имена приложений</string>
+
+    <string name="wide_vr">Использовать баннеры для VR приложений</string>
+    <string name="wide_2d">Использовать баннеры для 2D приложений</string>
+
     <string name="accessibility_event_name">[Библиотека приложений]</string>
+
+    <string name="launch_in">Запускать: в этом окне</string>
+    <string name="launch_out">Запускать: в собственном окне</string>
+
+    <string name="launch_title">Внимание!</string>
+
+    <string name="service_title">Инстукция</string>
+
+    <string name="cancel">Отмена</string>
+    <string name="understood">Понятно</string>
+    <string name="next">Продолжить</string>
+
+    <string name="edit_off">Включить режим редактирования</string>
+    <string name="edit_on">Выключить режим редактирования</string>
+
+    <string name="selection_hint">Нажмите на группу, чтобы переместить выбранное приложение.</string>
+    <string name="selection_hint_multiple">Приложений выделено: %d. Нажмите на группу, чтобы переместить.</string>
+
 </resources>

--- a/Launcher/App/src/main/res/values-sv/strings.xml
+++ b/Launcher/App/src/main/res/values-sv/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[Appbibliotek]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-zh-rCN/strings.xml
+++ b/Launcher/App/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[应用库]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-zh-rHK/strings.xml
+++ b/Launcher/App/src/main/res/values-zh-rHK/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[應用程式資料庫]</string>
+</resources>

--- a/Launcher/App/src/main/res/values-zh-rTW/strings.xml
+++ b/Launcher/App/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_event_name">[應用程式資料庫]</string>
+</resources>


### PR DESCRIPTION
Hey, just figure out why "Shortcut Service" doesn't work in some circumstances. The name of App Library depends on language settings in Quest.