### PR TITLE
Add missing Target SDK 34 and removed previously-used permissions

### DIFF
--- a/Launcher/App/build.gradle
+++ b/Launcher/App/build.gradle
@@ -4,7 +4,7 @@ android {
     defaultConfig {
         compileSdk 34
         minSdkVersion 24
-        targetSdk 33
+        targetSdk 34
         versionCode 724
         versionName "7.2.4"
     }

--- a/Launcher/App/build.gradle
+++ b/Launcher/App/build.gradle
@@ -4,7 +4,7 @@ android {
     defaultConfig {
         compileSdk 34
         minSdkVersion 24
-        targetSdk 34
+        targetSdkVersion 34
         versionCode 724
         versionName "7.2.4"
     }

--- a/Launcher/App/build.gradle
+++ b/Launcher/App/build.gradle
@@ -4,8 +4,9 @@ android {
     defaultConfig {
         compileSdk 34
         minSdkVersion 24
-        versionCode 723
-        versionName "7.2.3"
+        targetSdk 33
+        versionCode 724
+        versionName "7.2.4"
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/Launcher/App/src/main/AndroidManifest.xml
+++ b/Launcher/App/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES"/>
 
@@ -21,15 +20,6 @@
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
 
     <uses-permission android:name="com.oculus.permission.HAND_TRACKING"/>
-
-    <!-- Allows the app to play/record audio in backgroundy -->
-    <uses-permission android:name="com.oculus.permission.PLAY_AUDIO_BACKGROUND"/>
-    <uses-permission android:name="com.oculus.permission.RECORD_AUDIO_BACKGROUND"/>
-    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
 
     <uses-permission android:name="com.android.launcher.permission.READ_SETTINGS" />
     <uses-permission android:name="com.android.launcher.permission.WRITE_SETTINGS"

--- a/Launcher/App/src/main/AndroidManifest.xml
+++ b/Launcher/App/src/main/AndroidManifest.xml
@@ -17,7 +17,6 @@
 
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
-    <uses-feature android:name="android.hardware.microphone" android:required="false" />
 
     <uses-permission android:name="com.oculus.permission.HAND_TRACKING"/>
 


### PR DESCRIPTION
Suppresses "This app was built for an older version of Android. It might not work properly and doesn't include the latest security and privacy protections. Check for an update, or contact the app's developer." warning on Android 14.
One of the permissions were used as part of the built-in browser in previous versions of the launcher, but with the release of Lightning Browser, those permissions are no longer necessary.